### PR TITLE
DotNet7 upgrade

### DIFF
--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -13,7 +13,7 @@ variables:
   solution: '**/*.sln'
   buildPlatform: 'Any CPU'
   buildConfiguration: 'Release'
-  targetFramework: 'net6.0-windows'
+  dotNetVersionBuildDir: 'net7.0-windows'
   GitVersion.SemVer: ''
 
 steps:
@@ -108,7 +108,7 @@ steps:
 - task: CopyFiles@2
   displayName: Copy Build Files (1 of 3)
   inputs:
-    SourceFolder: '$(Build.SourcesDirectory)\src\EM.HostsManager.App\bin\$(BuildConfiguration)\$(targetFramework)'
+    SourceFolder: '$(Build.SourcesDirectory)\src\EM.HostsManager.App\bin\$(BuildConfiguration)\$(dotNetVersionBuildDir)'
     Contents: '**'
     TargetFolder: '$(Build.BinariesDirectory)'
     CleanTargetFolder: true
@@ -118,9 +118,9 @@ steps:
   displayName: Copy Build Files (2 of 3)
   inputs:
     Contents: |
-      $(Build.SourcesDirectory)\src\EM.HostsManager.App\bin\$(BuildConfiguration)\$(targetFramework)\EM.HostsManager.App.exe
-      $(Build.SourcesDirectory)\src\EM.HostsManager.App\bin\$(BuildConfiguration)\$(targetFramework)\EM.HostsManager.App.dll
-      $(Build.SourcesDirectory)\src\EM.HostsManager.App\bin\$(BuildConfiguration)\$(targetFramework)\EM.HostsManager.App.runtimeconfig.json
+      $(Build.SourcesDirectory)\src\EM.HostsManager.App\bin\$(BuildConfiguration)\$(dotNetVersionBuildDir)\EM.HostsManager.App.exe
+      $(Build.SourcesDirectory)\src\EM.HostsManager.App\bin\$(BuildConfiguration)\$(dotNetVersionBuildDir)\EM.HostsManager.App.dll
+      $(Build.SourcesDirectory)\src\EM.HostsManager.App\bin\$(BuildConfiguration)\$(dotNetVersionBuildDir)\EM.HostsManager.App.runtimeconfig.json
     TargetFolder: '$(Build.BinariesDirectory)\Deploy'
     CleanTargetFolder: true
     OverWrite: true

--- a/src/EM.HostsManager.App/EM.HostsManager.App.csproj
+++ b/src/EM.HostsManager.App/EM.HostsManager.App.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
 	<OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net7.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
     <Nullable>enable</Nullable>
     <ApplicationIcon>Icon_01.ico</ApplicationIcon>
@@ -54,7 +54,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitVersion.MsBuild" Version="5.9.0">
+    <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/EM.HostsManager.Installer/CodeDependencies.iss
+++ b/src/EM.HostsManager.Installer/CodeDependencies.iss
@@ -412,6 +412,18 @@ begin
   end;
 end;
 
+procedure Dependency_AddDotNet70Desktop;
+begin
+  // https://dotnet.microsoft.com/download/dotnet/7.0
+  if not Dependency_IsNetCoreInstalled('Microsoft.WindowsDesktop.App 7.0.0') then begin
+    Dependency_Add('windowsdesktop-runtime-7.0.0' + Dependency_ArchSuffix + '.exe',
+      '/lcid ' + IntToStr(GetUILanguage) + ' /passive /norestart',
+      '.NET Desktop Runtime 7.0.0' + Dependency_ArchTitle,
+      Dependency_String('https://download.visualstudio.microsoft.com/download/pr/5b2fbe00-507e-450e-8b52-43ab052aadf2/79d54c3a19ce3fce314f2367cf4e3b21/windowsdesktop-runtime-7.0.0-win-x64.exe'),
+      '', False, False);
+  end;
+end;
+
 procedure Dependency_AddVC2005;
 begin
   // https://www.microsoft.com/en-us/download/details.aspx?id=26347
@@ -622,6 +634,7 @@ end;
   #define UseDotNet60
   #define UseDotNet60Asp
   #define UseDotNet60Desktop
+  #define UseDotNet70Desktop
 #endif
 
 #define UseVC2005
@@ -750,6 +763,9 @@ begin
 #endif
 #ifdef UseDotNet60Desktop
   Dependency_AddDotNet60Desktop;
+#endif
+#ifdef UseDotNet70Desktop
+  Dependency_AddDotNet70Desktop;
 #endif
 
 #ifdef UseVC2005

--- a/src/EM.HostsManager.Installer/CodeDependencies.iss
+++ b/src/EM.HostsManager.Installer/CodeDependencies.iss
@@ -416,7 +416,7 @@ procedure Dependency_AddDotNet70Desktop;
 begin
   // https://dotnet.microsoft.com/download/dotnet/7.0
   if not Dependency_IsNetCoreInstalled('Microsoft.WindowsDesktop.App 7.0.0') then begin
-    Dependency_Add('windowsdesktop-runtime-7.0.0' + Dependency_ArchSuffix + '.exe',
+    Dependency_Add('windowsdesktop-runtime-7.0.0-win' + Dependency_ArchSuffix + '.exe',
       '/lcid ' + IntToStr(GetUILanguage) + ' /passive /norestart',
       '.NET Desktop Runtime 7.0.0' + Dependency_ArchTitle,
       Dependency_String('https://download.visualstudio.microsoft.com/download/pr/d05a833c-2cf9-4d06-89ae-a0f3e10c5c91/c668ff42e23c2f67aa3d80227860585f/windowsdesktop-runtime-7.0.0-win-x86.exe', 'https://download.visualstudio.microsoft.com/download/pr/5b2fbe00-507e-450e-8b52-43ab052aadf2/79d54c3a19ce3fce314f2367cf4e3b21/windowsdesktop-runtime-7.0.0-win-x64.exe'),

--- a/src/EM.HostsManager.Installer/CodeDependencies.iss
+++ b/src/EM.HostsManager.Installer/CodeDependencies.iss
@@ -419,7 +419,7 @@ begin
     Dependency_Add('windowsdesktop-runtime-7.0.0' + Dependency_ArchSuffix + '.exe',
       '/lcid ' + IntToStr(GetUILanguage) + ' /passive /norestart',
       '.NET Desktop Runtime 7.0.0' + Dependency_ArchTitle,
-      Dependency_String('https://download.visualstudio.microsoft.com/download/pr/5b2fbe00-507e-450e-8b52-43ab052aadf2/79d54c3a19ce3fce314f2367cf4e3b21/windowsdesktop-runtime-7.0.0-win-x64.exe'),
+      Dependency_String('https://download.visualstudio.microsoft.com/download/pr/d05a833c-2cf9-4d06-89ae-a0f3e10c5c91/c668ff42e23c2f67aa3d80227860585f/windowsdesktop-runtime-7.0.0-win-x86.exe', 'https://download.visualstudio.microsoft.com/download/pr/5b2fbe00-507e-450e-8b52-43ab052aadf2/79d54c3a19ce3fce314f2367cf4e3b21/windowsdesktop-runtime-7.0.0-win-x64.exe'),
       '', False, False);
   end;
 end;

--- a/src/EM.HostsManager.Installer/EM.Hosts-Manager.Installer.iss
+++ b/src/EM.HostsManager.Installer/EM.Hosts-Manager.Installer.iss
@@ -62,8 +62,8 @@ Source: "..\EM.HostsManager.App\bin\Release\{#DotNetVersionBuildDir}\EM.HostsMan
 ; Deps
 Source: "netcorecheck_x64.exe"; Flags: dontcopy noencryption
 
-; Currently 6.0.9
-Source: "dotnet60desktop_x64.exe"; Flags: dontcopy noencryption
+; Currently 7.0.0
+Source: "windowsdesktop-runtime-7.0.0-win-x64.exe"; Flags: dontcopy noencryption
 
 [Run]
 Filename: {app}\EM.HostsManager.App.exe; Description: {cm:LaunchProgram,{cm:AppName}}; Flags: nowait postinstall skipifsilent
@@ -78,21 +78,21 @@ LaunchProgram=Start Hosts Manager v{#InstallerVersion}
 [Code]
 function InitializeSetup: Boolean;
 begin
-  // We depend on the .NET 6.0 Desktop runtime so install it if needed (x64).
+  // We depend on the .NET 7.0 Desktop runtime so install it if needed (x64).
   // Note:
-  //   This is an embedded offline install, see how 'dotnet60desktop_x64.exe' is
+  //   This is an embedded offline install, see how 'windowsdesktop-runtime-7.0.0-win-x64.exe' is
   //   packed above and extracted below.
   //   This will make our installer much larger in size, but,
   //   will work well on machines that are offline or behind paranoid corporate firewalls.
   // Note:
-  //   This may be obvious, but, if the user already has a compatible .NET 6.0 Desktop runtime
+  //   This may be obvious, but, if the user already has a compatible .NET 7.0 Desktop runtime
   //   installed everything above will be skipped and the installer will just install Hosts Manager.
   //
   // Special thanks to all the contributors @ https://github.com/DomGries/InnoDependencyInstaller !
 
-  ExtractTemporaryFile('dotnet60desktop_x64.exe');
+  ExtractTemporaryFile('windowsdesktop-runtime-7.0.0-win-x64.exe');
 
-  Dependency_AddDotNet60Desktop;
+  Dependency_AddDotNet70Desktop;
   
   // ...
 

--- a/src/EM.HostsManager.Installer/EM.Hosts-Manager.Installer.iss
+++ b/src/EM.HostsManager.Installer/EM.Hosts-Manager.Installer.iss
@@ -63,7 +63,7 @@ Source: "..\EM.HostsManager.App\bin\Release\{#DotNetVersionBuildDir}\EM.HostsMan
 Source: "netcorecheck_x64.exe"; Flags: dontcopy noencryption
 
 ; Currently 7.0.0
-Source: "windowsdesktop-runtime-7.0.0-win-x64.exe"; Flags: dontcopy noencryption
+Source: "windowsdesktop-runtime-7.0.0-win_x64.exe"; Flags: dontcopy noencryption
 
 [Run]
 Filename: {app}\EM.HostsManager.App.exe; Description: {cm:LaunchProgram,{cm:AppName}}; Flags: nowait postinstall skipifsilent
@@ -80,7 +80,7 @@ function InitializeSetup: Boolean;
 begin
   // We depend on the .NET 7.0 Desktop runtime so install it if needed (x64).
   // Note:
-  //   This is an embedded offline install, see how 'windowsdesktop-runtime-7.0.0-win-x64.exe' is
+  //   This is an embedded offline install, see how 'windowsdesktop-runtime-7.0.0-win_x64.exe' is
   //   packed above and extracted below.
   //   This will make our installer much larger in size, but,
   //   will work well on machines that are offline or behind paranoid corporate firewalls.
@@ -90,7 +90,7 @@ begin
   //
   // Special thanks to all the contributors @ https://github.com/DomGries/InnoDependencyInstaller !
 
-  ExtractTemporaryFile('windowsdesktop-runtime-7.0.0-win-x64.exe');
+  ExtractTemporaryFile('windowsdesktop-runtime-7.0.0-win_x64.exe');
 
   Dependency_AddDotNet70Desktop;
   

--- a/src/EM.HostsManager.Installer/EM.Hosts-Manager.Installer.iss
+++ b/src/EM.HostsManager.Installer/EM.Hosts-Manager.Installer.iss
@@ -12,6 +12,8 @@
 #define public Dependency_NoExampleSetup
 #include "CodeDependencies.iss"
 
+#define DotNetVersionBuildDir "net7.0-windows"
+
 [Setup]
 ArchitecturesAllowed=x64
 ArchitecturesInstallIn64BitMode=x64
@@ -53,9 +55,9 @@ Root: HKLM; Subkey: "Software\Microsoft\Windows\CurrentVersion\Run"; ValueType: 
 [Files]
 Source: "License.txt"; DestDir: {app}; Flags: ignoreversion noencryption
 Source: "HostsManager.ico"; DestDir: {app}; Flags: ignoreversion noencryption  
-Source: "..\EM.HostsManager.App\bin\Release\net6.0-windows\EM.HostsManager.App.exe"; DestDir: "{app}"; Flags: ignoreversion noencryption
-Source: "..\EM.HostsManager.App\bin\Release\net6.0-windows\EM.HostsManager.App.dll"; DestDir: "{app}"; Flags: ignoreversion noencryption
-Source: "..\EM.HostsManager.App\bin\Release\net6.0-windows\EM.HostsManager.App.runtimeconfig.json"; DestDir: "{app}"; Flags: ignoreversion noencryption
+Source: "..\EM.HostsManager.App\bin\Release\{#DotNetVersionBuildDir}\EM.HostsManager.App.exe"; DestDir: "{app}"; Flags: ignoreversion noencryption
+Source: "..\EM.HostsManager.App\bin\Release\{#DotNetVersionBuildDir}\EM.HostsManager.App.dll"; DestDir: "{app}"; Flags: ignoreversion noencryption
+Source: "..\EM.HostsManager.App\bin\Release\{#DotNetVersionBuildDir}\EM.HostsManager.App.runtimeconfig.json"; DestDir: "{app}"; Flags: ignoreversion noencryption
 
 ; Deps
 Source: "netcorecheck_x64.exe"; Flags: dontcopy noencryption


### PR DESCRIPTION
Upgrade to dotnet7.

Build the application for dotnet7 and update the Installer to deploy the dotnet7.0 Desktop Runtime (offline).