### PR TITLE
Add code signing to application files and installer (self-signed test cert)

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -116,7 +116,6 @@ jobs:
           $signArgsAndFile = $signArgs + $fileToSign + "'"
           $cmd = "'${{ env.SIGNTOOL }}' " + $signArgsAndFile
           Write-Output $cmd
-#          Invoke-Expression $cmd
         }
         
     - name: Install Inno Setup (Publish)

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -114,8 +114,9 @@ jobs:
         Foreach ($fileToSign in $signFiles)
         {
           $signArgsAndFile = $signArgs + $fileToSign + "'"
-          $cmd = "'${{ env.SIGNTOOL }}' " + $signArgsAndFile
-          Write-Output $cmd
+          $signCmd = "'${{ env.SIGNTOOL }}' " + $signArgsAndFile
+          Write-Output $signCmd
+          Invoke-Expression $signCmd
         }
         
     - name: Install Inno Setup (Publish)

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -110,11 +110,11 @@ jobs:
       shell: powershell
       run: |
         $signFiles = @("EM.HostsManager.App.exe", "EM.HostsManager.dll")
-        $signArgs = "sign /f ${{ env.CERT_FILENAME }} /p ${{ secrets.Pfx_Key }} /t ${{ env.TIMESTAMP_URL }} /fd SHA256 "${{ env.APP_DIR }}\bin\${{ env.BUILD_CONFIG }}\${{ env.DOTNET_VER }}\"
+        $signArgs = "sign /f ${{ env.CERT_FILENAME }} /p ${{ secrets.Pfx_Key }} /t ${{ env.TIMESTAMP_URL }} /fd SHA256 ${{ env.APP_DIR }}\bin\${{ env.BUILD_CONFIG }}\${{ env.DOTNET_VER }}\"
         Foreach ($fileToSign in $signFiles)
         {
           $signArgsAndFile = $signArgs + $fileToSign
-          Write-Output ${{ env.SIGNTOOL }} $signArgsAndFile
+          Write-Output $signArgsAndFile
           ${{ env.SIGNTOOL }} $signArgsAndFile
         }
         

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -109,9 +109,14 @@ jobs:
       working-directory: "./src"
       shell: powershell
       run: |
-        $signArgs = "sign /f ${{ env.CERT_FILENAME }} /p ${{ secrets.Pfx_Key }} /t ${{ env.TIMESTAMP_URL }} /fd SHA256 "${{ env.APP_DIR }}\bin\${{ env.BUILD_CONFIG }}\${{ env.DOTNET_VER }}"
-        ${{ env.SIGNTOOL }} $signArgs+"\EM.HostsManager.dll"
-        ${{ env.SIGNTOOL }} $signArgs+"\EM.HostsManager.App.exe"
+        $signFiles = @("EM.HostsManager.App.exe", "EM.HostsManager.dll")
+        $signArgs = "sign /f ${{ env.CERT_FILENAME }} /p ${{ secrets.Pfx_Key }} /t ${{ env.TIMESTAMP_URL }} /fd SHA256 "${{ env.APP_DIR }}\bin\${{ env.BUILD_CONFIG }}\${{ env.DOTNET_VER }}\"
+        Foreach ($fileToSign in $signFiles)
+        {
+          $signArgsAndFile = $signArgs + $fileToSign
+          Write-Output ${{ env.SIGNTOOL }} $signArgsAndFile
+          ${{ env.SIGNTOOL }} $signArgsAndFile
+        }
         
     - name: Install Inno Setup (Publish)
       #if: github.ref == 'refs/heads/main'

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -110,8 +110,8 @@ jobs:
       shell: powershell
       run: |
         $signArgs = "sign /f ${{ env.CERT_FILENAME }} /p ${{ secrets.Pfx_Key }} /t ${{ env.TIMESTAMP_URL }} /fd SHA256 "${{ env.APP_DIR }}\bin\${{ env.BUILD_CONFIG }}\${{ env.DOTNET_VER }}\"
-        ${{ env.SIGNTOOL }} $signArgs + "EM.HostsManager.dll"
-        ${{ env.SIGNTOOL }} $signArgs + "EM.HostsManager.App.exe"
+        ${{ env.SIGNTOOL }} $signArgs"EM.HostsManager.dll"
+        ${{ env.SIGNTOOL }} $signArgs"EM.HostsManager.App.exe"
         
     - name: Install Inno Setup (Publish)
       #if: github.ref == 'refs/heads/main'

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -129,7 +129,7 @@ jobs:
     - name: Clean up
       if: success() || failure()
       #if: github.ref == 'refs/heads/main'
-      shell: cmd
+      shell: powershell
       working-directory: "./src"
       run: Remove-Item -path ${{ env.CERT_FILENAME }}
 

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -127,6 +127,7 @@ jobs:
 
     # Remove Code-Signing pfx
     - name: Clean up
+      if: success() || failure()
       #if: github.ref == 'refs/heads/main'
       shell: cmd
       working-directory: "./src"

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -20,19 +20,19 @@ jobs:
     - uses: actions/checkout@v2
     
     - name: Fetch all history and tags (Publish)
-      #if: github.ref == 'refs/heads/main'
+      if: github.ref == 'refs/heads/main'
       run: |
         git fetch --unshallow --prune
 
     - name: Install GitVersion (Publish)
-      #if: github.ref == 'refs/heads/main'
+      if: github.ref == 'refs/heads/main'
       uses: gittools/actions/gitversion/setup@v0.9.10
       with:
         versionSpec: '5.x'
         includePrerelease: false
   
     - name: Determine Version (Publish)
-      #if: github.ref == 'refs/heads/main'
+      if: github.ref == 'refs/heads/main'
       id: gitversion
       uses: gittools/actions/gitversion/execute@v0.9.10
       with:
@@ -41,7 +41,7 @@ jobs:
         additionalArguments: '-ensureassemblyinfo'
 
     - name: Display Version (Publish)
-      #if: github.ref == 'refs/heads/main'
+      if: github.ref == 'refs/heads/main'
       shell: powershell
       run: |
         Write-Output "==============================================================================================================================================="
@@ -54,7 +54,7 @@ jobs:
         dotnet-version: 7.0.x
 
     - name: Patch BuildDateAttribute (Publish)
-      #if: github.ref == 'refs/heads/main'
+      if: github.ref == 'refs/heads/main'
       shell: powershell
       run: |
         Write-Output "==============================================================================================================================================="
@@ -71,7 +71,7 @@ jobs:
         Write-Output "==============================================================================================================================================="
 
     - name: Patch CommitIdAttribute (Publish)
-      #if: github.ref == 'refs/heads/main'
+      if: github.ref == 'refs/heads/main'
       shell: powershell
       run: |
         Write-Output "==============================================================================================================================================="
@@ -88,15 +88,15 @@ jobs:
         Write-Output "==============================================================================================================================================="
 
     - name: Build HostsManager (Check)
-      #if: github.ref != 'refs/heads/main'
+      if: github.ref != 'refs/heads/main'
       run: dotnet build "./src" --configuration Release
     
     - name: Build HostsManager with Version (Publish)
-      #if: github.ref == 'refs/heads/main'
+      if: github.ref == 'refs/heads/main'
       run: dotnet build "./src" --configuration Release -p:Version=${{ steps.gitversion.outputs.MajorMinorPatch }} -p:FileVersion=${{ steps.gitversion.outputs.MajorMinorPatch }}
 
     - name: Decode Code-Signing Pfx
-      #if: github.ref == 'refs/heads/main'
+      if: github.ref == 'refs/heads/main'
       working-directory: "./src"
       shell: powershell
       run: |
@@ -105,7 +105,7 @@ jobs:
         [IO.File]::WriteAllBytes("$certificatePath", $pfx_cert_byte)
 
     - name: Sign Application Files (Post Build)
-      #if: github.ref == 'refs/heads/main'
+      if: github.ref == 'refs/heads/main'
       working-directory: "./src"
       shell: powershell
       run: |
@@ -120,19 +120,19 @@ jobs:
         }
         
     - name: Install Inno Setup (Publish)
-      #if: github.ref == 'refs/heads/main'
+      if: github.ref == 'refs/heads/main'
       shell: cmd
       run: |
         choco install innosetup
 
     - name: Build Installer (Publish)
-      #if: github.ref == 'refs/heads/main'
+      if: github.ref == 'refs/heads/main'
       working-directory: "./src/${{ env.INSTALLER_DIR }}"
       run: |
         iscc.exe EM.HostsManager.Installer.iss /DInstallerVersion=${{ steps.gitversion.outputs.MajorMinorPatch }}
 
     - name: Sign Installer (Post Build)
-      #if: github.ref == 'refs/heads/main'
+      if: github.ref == 'refs/heads/main'
       working-directory: "./src"
       shell: powershell
       run: |
@@ -147,15 +147,14 @@ jobs:
         }
 
     - name: Clean up (Code Signing Pfx)
-      if: success() || failure()
-      #if: github.ref == 'refs/heads/main'
+      if: (github.ref == 'refs/heads/main' && success() || failure())
       shell: powershell
       working-directory: "./src"
       continue-on-error: true
       run: Remove-Item -Verbose -Path ${{ env.CERT_FILENAME }}
 
     - name: Copy Build Files (1 of 3)
-      #if: github.ref == 'refs/heads/main'
+      if: github.ref == 'refs/heads/main'
       shell: cmd
       working-directory: "./src"
       run: |
@@ -163,7 +162,7 @@ jobs:
         copy "${{ env.APP_DIR }}\bin\${{ env.BUILD_CONFIG }}\${{ env.DOTNET_VER }}\*.*" "Binaries"
 
     - name: Copy Build Files (2 of 3)
-      #if: github.ref == 'refs/heads/main'
+      if: github.ref == 'refs/heads/main'
       shell: cmd
       working-directory: "./src"
       run: |
@@ -175,7 +174,7 @@ jobs:
         copy "${{ env.APP_DIR }}\bin\${{ env.BUILD_CONFIG }}\${{ env.DOTNET_VER }}\EM.HostsManager.App.runtimeconfig.json" "Binaries\Deploy"
 
     - name: Copy Build Files (3 of 3)
-      #if: github.ref == 'refs/heads/main'
+      if: github.ref == 'refs/heads/main'
       shell: cmd
       working-directory: "./src"
       run: |
@@ -195,7 +194,7 @@ jobs:
     #    git push --force --tags origin
 
     - name: Publish build artifacts
-      #if: github.ref == 'refs/heads/main'
+      if: github.ref == 'refs/heads/main'
       uses: actions/upload-artifact@v3
       with:
         name: EM.HostsManager-${{steps.gitversion.outputs.MajorMinorPatch}}

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -114,8 +114,8 @@ jobs:
         Foreach ($fileToSign in $signFiles)
         {
           $signArgsAndFile = $signArgs + $fileToSign + "'"
-          Write-Output $signArgsAndFile
-          "${{ env.SIGNTOOL }}" $signArgsAndFile
+          Write-Output "${{ env.CERT_FILENAME}}" + $signArgsAndFile
+          Invoke-Expression "${{ env.CERT_FILENAME}}" + $signArgsAndFile
         }
         
     - name: Install Inno Setup (Publish)

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -6,30 +6,33 @@ on:
     
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: windows-2022
     env:
       BUILD_CONFIG: "Release"
       DOTNET_VER: "net7.0-windows"
       APP_DIR: "EM.HostsManager.App"
       INSTALLER_DIR: "EM.HostsManager.Installer"
-      
+      SIGNTOOL: "C:/Program Files (x86)/Windows Kits/10/bin/10.0.22621.0/x86/signtool.exe"  # See list of installed Windows SDK's @ https://github.com/actions/runner-images/blob/main/images/win/Windows2022-Readme.md
+      TIMESTAMP_URL: "http://timestamp.digicert.com"
+      CERT_FILENAME: "Sign.pfx"
+
     steps:
     - uses: actions/checkout@v2
     
     - name: Fetch all history and tags (Publish)
-      if: github.ref == 'refs/heads/main'
+      #if: github.ref == 'refs/heads/main'
       run: |
         git fetch --unshallow --prune
 
     - name: Install GitVersion (Publish)
-      if: github.ref == 'refs/heads/main'
+      #if: github.ref == 'refs/heads/main'
       uses: gittools/actions/gitversion/setup@v0.9.10
       with:
         versionSpec: '5.x'
         includePrerelease: false
   
     - name: Determine Version (Publish)
-      if: github.ref == 'refs/heads/main'
+      #if: github.ref == 'refs/heads/main'
       id: gitversion
       uses: gittools/actions/gitversion/execute@v0.9.10
       with:
@@ -38,11 +41,11 @@ jobs:
         additionalArguments: '-ensureassemblyinfo'
 
     - name: Display Version (Publish)
-      if: github.ref == 'refs/heads/main'
+      #if: github.ref == 'refs/heads/main'
       shell: powershell
       run: |
         Write-Output "==============================================================================================================================================="
-        Write-Output "Version : ${{steps.gitversion.outputs.MajorMinorPatch}}"
+        Write-Output "Version : ${{ steps.gitversion.outputs.MajorMinorPatch }}"
         Write-Output "==============================================================================================================================================="
 
     - name: Setup .NET 7.0
@@ -51,7 +54,7 @@ jobs:
         dotnet-version: 7.0.x
 
     - name: Patch BuildDateAttribute (Publish)
-      if: github.ref == 'refs/heads/main'
+      #if: github.ref == 'refs/heads/main'
       shell: powershell
       run: |
         Write-Output "==============================================================================================================================================="
@@ -59,7 +62,7 @@ jobs:
         Write-Output "==============================================================================================================================================="
         $buildDateAttribute = [DateTime]::UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ")
         Write-Output "Using: '$buildDateAttribute'"
-        $dir = "./src/${{env.APP_DIR}}"
+        $dir = "./src/${{ env.APP_DIR }}"
         Write-Output "Currently in: '$dir'"
         $fileLocation = Join-Path $dir -ChildPath "Program.BuildDate.cs" 
         $placeHolder = "BUILD-DATE-ATTRIBUTE"
@@ -68,7 +71,7 @@ jobs:
         Write-Output "==============================================================================================================================================="
 
     - name: Patch CommitIdAttribute (Publish)
-      if: github.ref == 'refs/heads/main'
+      #if: github.ref == 'refs/heads/main'
       shell: powershell
       run: |
         Write-Output "==============================================================================================================================================="
@@ -76,7 +79,7 @@ jobs:
         Write-Output "==============================================================================================================================================="
         $commitIdAttribute = git log --format="%H" -n 1
         Write-Output "Using: '$commitIdAttribute'"
-        $dir = "./src/${{env.APP_DIR}}"
+        $dir = "./src/${{ env.APP_DIR }}"
         Write-Output "Currently in: '$dir'"
         $fileLocation = Join-Path $dir -ChildPath "Program.CommitId.cs" 
         $placeHolder = "COMMIT-ID-ATTRIBUTE"
@@ -85,54 +88,79 @@ jobs:
         Write-Output "==============================================================================================================================================="
 
     - name: Build HostsManager (Check)
-      if: github.ref != 'refs/heads/main'
+      #if: github.ref != 'refs/heads/main'
       run: dotnet build "./src" --configuration Release
     
     - name: Build HostsManager with Version (Publish)
-      if: github.ref == 'refs/heads/main'
-      run: dotnet build "./src" --configuration Release -p:Version=${{steps.gitversion.outputs.MajorMinorPatch}} -p:FileVersion=${{steps.gitversion.outputs.MajorMinorPatch}}
+      #if: github.ref == 'refs/heads/main'
+      run: dotnet build "./src" --configuration Release -p:Version=${{ steps.gitversion.outputs.MajorMinorPatch }} -p:FileVersion=${{ steps.gitversion.outputs.MajorMinorPatch }}
+
+    - name: Decode Code-Signing Pfx
+      #if: github.ref == 'refs/heads/main'
+      working-directory: "./src"
+      shell: powershell
+      run: |
+        $pfx_cert_byte = [System.Convert]::FromBase64String("${{ secrets.Base64_Encoded_Pfx }}")
+        $certificatePath = Join-Path -Path . -ChildPath ${{ env.CERT_FILENAME}}
+        [IO.File]::WriteAllBytes("$certificatePath", $pfx_cert_byte)
+
+    - name: Sign Application Files (Post Build)
+      #if: github.ref == 'refs/heads/main'
+      working-directory: "./src"
+      shell: powershell
+      run: |
+        $signArgs = "sign /f ${{ env.CERT_FILENAME }} /p ${{ secrets.Pfx_Key }} /t ${{ env.TIMESTAMP_URL }} /fd SHA256 "${{ env.APP_DIR }}\bin\${{ env.BUILD_CONFIG }}\${{ env.DOTNET_VER }}\"
+        ${{ env.SIGNTOOL }} $signArgs + "EM.HostsManager.dll"
+        ${{ env.SIGNTOOL }} $signArgs + "EM.HostsManager.App.exe"
         
     - name: Install Inno Setup (Publish)
-      if: github.ref == 'refs/heads/main'
+      #if: github.ref == 'refs/heads/main'
       shell: cmd
       run: |
         choco install innosetup
 
     - name: Build Installer (Publish)
-      if: github.ref == 'refs/heads/main'
-      working-directory: "./src/${{env.INSTALLER_DIR}}"
+      #if: github.ref == 'refs/heads/main'
+      working-directory: "./src/${{ env.INSTALLER_DIR }}"
       run: |
-        iscc.exe EM.HostsManager.Installer.iss /DInstallerVersion=${{steps.gitversion.outputs.MajorMinorPatch}}
+        iscc.exe EM.HostsManager.Installer.iss /DInstallerVersion=${{ steps.gitversion.outputs.MajorMinorPatch }}
+
+    # Remove Code-Signing pfx
+    - name: Clean up
+      #if: github.ref == 'refs/heads/main'
+      shell: cmd
+      working-directory: "./src"
+      run: Remove-Item -path ${{ env.CERT_FILENAME }}
 
     - name: Copy Build Files (1 of 3)
-      if: github.ref == 'refs/heads/main'
+      #if: github.ref == 'refs/heads/main'
       shell: cmd
       working-directory: "./src"
       run: |
         if not exist Binaries mkdir Binaries
-        copy "${{env.APP_DIR}}\bin\${{env.BUILD_CONFIG}}\${{env.DOTNET_VER}}\*.*" "Binaries"
+        copy "${{ env.APP_DIR }}\bin\${{ env.BUILD_CONFIG }}\${{ env.DOTNET_VER }}\*.*" "Binaries"
 
     - name: Copy Build Files (2 of 3)
-      if: github.ref == 'refs/heads/main'
+      #if: github.ref == 'refs/heads/main'
       shell: cmd
       working-directory: "./src"
       run: |
         cd Binaries
         if not exist Deploy mkdir Deploy
         cd ..
-        copy "${{env.APP_DIR}}\bin\${{env.BUILD_CONFIG}}\${{env.DOTNET_VER}}\EM.HostsManager.App.exe" "Binaries\Deploy"
-        copy "${{env.APP_DIR}}\bin\${{env.BUILD_CONFIG}}\${{env.DOTNET_VER}}\EM.HostsManager.App.dll" "Binaries\Deploy"
-        copy "${{env.APP_DIR}}\bin\${{env.BUILD_CONFIG}}\${{env.DOTNET_VER}}\EM.HostsManager.App.runtimeconfig.json" "Binaries\Deploy"
+        copy "${{ env.APP_DIR }}\bin\${{ env.BUILD_CONFIG }}\${{ env.DOTNET_VER }}\EM.HostsManager.App.exe" "Binaries\Deploy"
+        copy "${{ env.APP_DIR }}\bin\${{ env.BUILD_CONFIG }}\${{ env.DOTNET_VER }}\EM.HostsManager.App.dll" "Binaries\Deploy"
+        copy "${{ env.APP_DIR }}\bin\${{ env.BUILD_CONFIG }}\${{ env.DOTNET_VER }}\EM.HostsManager.App.runtimeconfig.json" "Binaries\Deploy"
 
     - name: Copy Build Files (3 of 3)
-      if: github.ref == 'refs/heads/main'
+      #if: github.ref == 'refs/heads/main'
       shell: cmd
       working-directory: "./src"
       run: |
         cd Binaries
         if not exist Installer mkdir Installer
         cd ..
-        copy "${{env.INSTALLER_DIR}}\Output" "Binaries\Installer"
+        copy "${{ env.INSTALLER_DIR }}\Output" "Binaries\Installer"
 
     # Right now I'm manually tagging the repo for this project.
     # This may change in the future.
@@ -145,7 +173,7 @@ jobs:
     #    git push --force --tags origin
 
     - name: Publish build artifacts
-      if: github.ref == 'refs/heads/main'
+      #if: github.ref == 'refs/heads/main'
       uses: actions/upload-artifact@v3
       with:
         name: EM.HostsManager-${{steps.gitversion.outputs.MajorMinorPatch}}

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -136,7 +136,7 @@ jobs:
       working-directory: "./src"
       shell: powershell
       run: |
-        $signFiles = @("EM.HostsManager.Installer." + ${{ steps.gitversion.outputs.MajorMinorPatch }} + ".exe")
+        $signFiles = @("EM.HostsManager.Installer.${{ steps.gitversion.outputs.MajorMinorPatch }}.exe")
         $signDir = "${{ env.INSTALLER_DIR }}\Output\"
         $signArgs = " sign /f '${{ env.CERT_FILENAME }}' /p '${{ secrets.Pfx_Key }}' /t '${{ env.TIMESTAMP_URL }}' /fd 'SHA256' "
         Foreach ($fileToSign in $signFiles)

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -114,7 +114,7 @@ jobs:
         Foreach ($fileToSign in $signFiles)
         {
           $signArgsAndFile = $signArgs + $fileToSign + "'"
-          $signCmd = "'${{ env.SIGNTOOL }}' " + $signArgsAndFile
+          $signCmd = "cmd.exe /c '${{ env.SIGNTOOL }}' " + $signArgsAndFile
           Write-Output $signCmd
           Invoke-Expression $signCmd
         }

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -110,8 +110,8 @@ jobs:
       shell: powershell
       run: |
         $signArgs = "sign /f ${{ env.CERT_FILENAME }} /p ${{ secrets.Pfx_Key }} /t ${{ env.TIMESTAMP_URL }} /fd SHA256 "${{ env.APP_DIR }}\bin\${{ env.BUILD_CONFIG }}\${{ env.DOTNET_VER }}"
-        ${{ env.SIGNTOOL }} "$signArgs\EM.HostsManager.dll"
-        ${{ env.SIGNTOOL }} "$signArgs\EM.HostsManager.App.exe"
+        ${{ env.SIGNTOOL }} $signArgs+"\EM.HostsManager.dll"
+        ${{ env.SIGNTOOL }} $signArgs+"\EM.HostsManager.App.exe"
         
     - name: Install Inno Setup (Publish)
       #if: github.ref == 'refs/heads/main'

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -14,7 +14,7 @@ jobs:
       INSTALLER_DIR: "EM.HostsManager.Installer"
       SIGNTOOL: "C:/Program Files (x86)/Windows Kits/10/bin/10.0.22621.0/x86/signtool.exe"  # See list of installed Windows SDK's @ https://github.com/actions/runner-images/blob/main/images/win/Windows2022-Readme.md
       TIMESTAMP_URL: "http://timestamp.digicert.com"
-      CERT_FILENAME: "Sign.pfx"
+      CERT_FILENAME: "Cert.pfx"
 
     steps:
     - uses: actions/checkout@v2
@@ -109,13 +109,13 @@ jobs:
       working-directory: "./src"
       shell: powershell
       run: |
-        $signFiles = @("EM.HostsManager.App.exe", "EM.HostsManager.dll")
-        $signArgs = "sign /f '${{ env.CERT_FILENAME }}' /p '${{ secrets.Pfx_Key }}' /t '${{ env.TIMESTAMP_URL }}' /fd SHA256 '${{ env.APP_DIR }}\bin\${{ env.BUILD_CONFIG }}\${{ env.DOTNET_VER }}\"
+        $signFiles = @("EM.HostsManager.App.exe", "EM.HostsManager.App.dll")
+        $signDir = "${{ env.APP_DIR }}\bin\${{ env.BUILD_CONFIG }}\${{ env.DOTNET_VER }}\"
+        $signArgs = " sign /f '${{ env.CERT_FILENAME }}' /p '${{ secrets.Pfx_Key }}' /t '${{ env.TIMESTAMP_URL }}' /fd 'SHA256' "
         Foreach ($fileToSign in $signFiles)
         {
-          $signArgsAndFile = $signArgs + $fileToSign + "'"
-          $signCmd = "cmd.exe /c '${{ env.SIGNTOOL }}' " + $signArgsAndFile
-          Write-Output $signCmd
+          $signArgsAndFile = $signArgs + "'" + $signDir + $fileToSign + "'"
+          $signCmd = "cmd /c '${{ env.SIGNTOOL }}' " + $signArgsAndFile
           Invoke-Expression $signCmd
         }
         
@@ -131,11 +131,12 @@ jobs:
       run: |
         iscc.exe EM.HostsManager.Installer.iss /DInstallerVersion=${{ steps.gitversion.outputs.MajorMinorPatch }}
 
-    - name: Clean up (Code Signing)
+    - name: Clean up (Code Signing Pfx)
       if: success() || failure()
       #if: github.ref == 'refs/heads/main'
       shell: powershell
       working-directory: "./src"
+      continue-on-error: true
       run: Remove-Item -Verbose -Path ${{ env.CERT_FILENAME }}
 
     - name: Copy Build Files (1 of 3)

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -131,6 +131,21 @@ jobs:
       run: |
         iscc.exe EM.HostsManager.Installer.iss /DInstallerVersion=${{ steps.gitversion.outputs.MajorMinorPatch }}
 
+    - name: Sign Installer (Post Build)
+      #if: github.ref == 'refs/heads/main'
+      working-directory: "./src"
+      shell: powershell
+      run: |
+        $signFiles = @("EM.HostsManager.Installer." + ${{ steps.gitversion.outputs.MajorMinorPatch }} + ".exe")
+        $signDir = "${{ env.INSTALLER_DIR }}\Output\"
+        $signArgs = " sign /f '${{ env.CERT_FILENAME }}' /p '${{ secrets.Pfx_Key }}' /t '${{ env.TIMESTAMP_URL }}' /fd 'SHA256' "
+        Foreach ($fileToSign in $signFiles)
+        {
+          $signArgsAndFile = $signArgs + "'" + $signDir + $fileToSign + "'"
+          $signCmd = "cmd /c '${{ env.SIGNTOOL }}' " + $signArgsAndFile
+          Invoke-Expression $signCmd
+        }
+
     - name: Clean up (Code Signing Pfx)
       if: success() || failure()
       #if: github.ref == 'refs/heads/main'

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -114,8 +114,9 @@ jobs:
         Foreach ($fileToSign in $signFiles)
         {
           $signArgsAndFile = $signArgs + $fileToSign + "'"
-          Write-Output "${{ env.CERT_FILENAME}}" + $signArgsAndFile
-          Invoke-Expression "${{ env.CERT_FILENAME}}" + $signArgsAndFile
+          $cmd = "'${{ env.SIGNTOOL }}' " + $signArgsAndFile
+          Write-Output $cmd
+#          Invoke-Expression $cmd
         }
         
     - name: Install Inno Setup (Publish)

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -110,12 +110,12 @@ jobs:
       shell: powershell
       run: |
         $signFiles = @("EM.HostsManager.App.exe", "EM.HostsManager.dll")
-        $signArgs = "sign /f ${{ env.CERT_FILENAME }} /p ${{ secrets.Pfx_Key }} /t ${{ env.TIMESTAMP_URL }} /fd SHA256 ${{ env.APP_DIR }}\bin\${{ env.BUILD_CONFIG }}\${{ env.DOTNET_VER }}\"
+        $signArgs = "sign /f '${{ env.CERT_FILENAME }}' /p '${{ secrets.Pfx_Key }}' /t '${{ env.TIMESTAMP_URL }}' /fd SHA256 '${{ env.APP_DIR }}\bin\${{ env.BUILD_CONFIG }}\${{ env.DOTNET_VER }}\"
         Foreach ($fileToSign in $signFiles)
         {
-          $signArgsAndFile = $signArgs + $fileToSign
+          $signArgsAndFile = $signArgs + $fileToSign + "'"
           Write-Output $signArgsAndFile
-          ${{ env.SIGNTOOL }} $signArgsAndFile
+          "${{ env.SIGNTOOL }}" $signArgsAndFile
         }
         
     - name: Install Inno Setup (Publish)

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -109,9 +109,9 @@ jobs:
       working-directory: "./src"
       shell: powershell
       run: |
-        $signArgs = "sign /f ${{ env.CERT_FILENAME }} /p ${{ secrets.Pfx_Key }} /t ${{ env.TIMESTAMP_URL }} /fd SHA256 "${{ env.APP_DIR }}\bin\${{ env.BUILD_CONFIG }}\${{ env.DOTNET_VER }}\"
-        ${{ env.SIGNTOOL }} $signArgs"EM.HostsManager.dll"
-        ${{ env.SIGNTOOL }} $signArgs"EM.HostsManager.App.exe"
+        $signArgs = "sign /f ${{ env.CERT_FILENAME }} /p ${{ secrets.Pfx_Key }} /t ${{ env.TIMESTAMP_URL }} /fd SHA256 "${{ env.APP_DIR }}\bin\${{ env.BUILD_CONFIG }}\${{ env.DOTNET_VER }}"
+        ${{ env.SIGNTOOL }} "$signArgs\EM.HostsManager.dll"
+        ${{ env.SIGNTOOL }} "$signArgs\EM.HostsManager.App.exe"
         
     - name: Install Inno Setup (Publish)
       #if: github.ref == 'refs/heads/main'
@@ -125,13 +125,12 @@ jobs:
       run: |
         iscc.exe EM.HostsManager.Installer.iss /DInstallerVersion=${{ steps.gitversion.outputs.MajorMinorPatch }}
 
-    # Remove Code-Signing pfx
-    - name: Clean up
+    - name: Clean up (Code Signing)
       if: success() || failure()
       #if: github.ref == 'refs/heads/main'
       shell: powershell
       working-directory: "./src"
-      run: Remove-Item -path ${{ env.CERT_FILENAME }}
+      run: Remove-Item -Verbose -Path ${{ env.CERT_FILENAME }}
 
     - name: Copy Build Files (1 of 3)
       #if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
* Note: Currently using a self-signed test certificate embedded as repo secrets (base64 encoded pfx + key, as per https://github.com/microsoft/github-actions-for-desktop-apps#signing). Can be easily replaced with a real cert later.